### PR TITLE
Updates commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
             <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
-                <version>3.2.1</version>
+                <version>3.2.2</version>
             </dependency>
             <dependency>
                 <groupId>commons-lang</groupId>


### PR DESCRIPTION
There is a security issue with commons-collections 3.2.1 (https://commons.apache.org/proper/commons-collections/security-reports.html)

This updates the dependency in what should be a easy patch.

Unless the portlet is deserializing objects, this shouldn't affect the portlet.

I'm going to merge this now, get this into the test tier.  Please test and cut a patch release soon, so this can get to production.