### PR TITLE
CG-266: Add redirect parameters for instructionMode and ethnicStudies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 CampusCourseGuideRedirector
 ===========================
+
+A portlet used to proxy deterministic search URLs into portlet parameters
+Course Guide can parse to render a canned search.
+
+See [Course Guide Public URLs](https://wiki.doit.wisc.edu/confluence/x/F4XVAg)
+for examples.

--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,25 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>edu.wisc.doit.code</groupId>
         <artifactId>shared-tools-uw-parent</artifactId>
-        <version>7</version>
+        <version>9</version>
     </parent>
     
-    <modelVersion>4.0.0</modelVersion>
     <groupId>edu.wisc.my.portlet.campuscourseguideredirector</groupId>
     <artifactId>CourseGuideRedirect</artifactId>
-    <packaging>war</packaging>
-    <name>Course Guide Redirector</name>
     <version>1.0.3-SNAPSHOT</version>
+    <packaging>war</packaging>
+
+    <name>Course Guide Redirector</name>
     <description>Redirects requests based on if a user is authenticated or not to other locations</description>
-    
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spring.version>4.3.5.RELEASE</spring.version>
+    </properties>
+
     <prerequisites>
         <maven>3.0.0</maven>
     </prerequisites>
@@ -22,9 +28,8 @@
         <connection>scm:git:git@github.com:UW-Madison-DoIT/CampusCourseGuideRedirector.git</connection>
         <developerConnection>scm:git:git@github.com:UW-Madison-DoIT/CampusCourseGuideRedirector.git</developerConnection>
         <url>https://github.com/UW-Madison-DoIT/CampusCourseGuideRedirector</url>
-        <tag>HEAD</tag>
-	</scm>
-    
+    </scm>
+
     <repositories>
         <repository>
             <id>code.doit-public-releases</id>
@@ -61,35 +66,27 @@
             </snapshots>
         </repository>
     </repositories>
-    
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-    
-    
 
-    
-    <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>commons-collections</groupId>
-                <artifactId>commons-collections</artifactId>
-                <version>3.2.2</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-collections4</artifactId>
+                <version>4.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-lang</groupId>
                 <artifactId>commons-lang</artifactId>
-                <version>2.4</version>
+                <version>2.6</version>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
-                <version>1.1.1</version>
+                <version>1.2</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>1.4</version>
+                <version>2.5</version>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>
@@ -99,12 +96,12 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.4</version>
+                <version>4.12</version>
             </dependency>
             <dependency>
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
-                <version>1.2.15</version>
+                <version>1.2.17</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.sun.jdmk</groupId>
@@ -127,142 +124,35 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-context</artifactId>
-                <version>2.5.6</version>
+                <version>${spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-core</artifactId>
-                <version>2.5.6</version>
+                <version>${spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-web</artifactId>
-                <version>2.5.6</version>
+                <version>${spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-webmvc</artifactId>
-                <version>2.5.6</version>
+                <version>${spring.version}</version>
             </dependency>
         </dependencies>
-    </dependencyManagement>
-    
-    <dependencies>
-        <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.sun.jdmk</groupId>
-                    <artifactId>jmxtools</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jmx</groupId>
-                    <artifactId>jmxri</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.jms</groupId>
-                    <artifactId>jms</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.mail</groupId>
-                    <artifactId>mail</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency> 
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-webmvc</artifactId>
-        </dependency>
 
-        
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        
-        
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-
-	<build>
+    <build>
         <finalName>CourseGuideRedirect</finalName>
         <plugins>
             <plugin>
-                <groupId>org.jasig.maven</groupId>
-                <artifactId>maven-notice-plugin</artifactId>
-                <version>1.0.5</version>
-                <configuration>
-                    <generateChildNotices>false</generateChildNotices>
-                    <noticeTemplate>NOTICE.template</noticeTemplate>
-                    <noticeMessage>NOTICE</noticeMessage>
-                    <licenseMapping>
-                        <param>https://source.jasig.org/licenses/license-mappings.xml</param>
-                    </licenseMapping>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>enforce-versions</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <bannedDependencies>
-                                    <excludes>
-                                    	<!-- TODO -->
-                                        <!-- <exclude>commons-logging:commons-logging</exclude>
-                                        <exclude>commons-logging:commons-logging-api</exclude>
-                                        <exclude>log4j:log4j</exclude> -->
-                                    </excludes>
-                                </bannedDependencies>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.2</version>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.0</version>
                 <configuration>
-                    <tagNameFormat>@{project.version}</tagNameFormat>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/applicationContext.xml
@@ -23,6 +23,7 @@
                 <entry key="attrCode" value="specialGroupType" />
                 <entry key="attrValue" value="specialGroup" />
                 <entry key="ethnicStudies" value="ethnicStudies"/>
+                <entry key="instructionMode" value="instructionMode"/>
             </map>
         </property>
         <property name="conditionalParameterMappings">

--- a/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/applicationContext.xml
@@ -2,12 +2,15 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
-    
-    <bean id="browseByTitleRedirect" class="edu.wisc.my.redirect.PortalUrlRedirectController">
+
+    <bean id="abstractRedirectBean" abstract="true" class="edu.wisc.my.redirect.PortalUrlRedirectController">
         <property name="strictParameterMatching" value="false" />
         <property name="portalUrlProvider" ref="portalUrlProvider" />
         <property name="portletFunctionalName" value="CourseGuide-Browse-Courses" />
         <property name="windowState" value="detached" />
+    </bean>
+
+    <bean id="browseByTitleRedirect" parent="abstractRedirectBean">
         <property name="staticParameters">
             <map>
                 <entry key="action" value="advancedSearch" />
@@ -19,15 +22,21 @@
                 <entry key="termCode" value="termChoice" />
                 <entry key="attrCode" value="specialGroupType" />
                 <entry key="attrValue" value="specialGroup" />
+                <entry key="ethnicStudies" value="ethnicStudies"/>
+            </map>
+        </property>
+        <property name="conditionalParameterMappings">
+            <map>
+                <entry key="ethnicStudies">
+                    <map>
+                        <entry key="_ethnicStudies" value="_on"/>
+                    </map>
+                </entry>
             </map>
         </property>
     </bean>
     
-    <bean id="browseBySubjectRedirect" class="edu.wisc.my.redirect.PortalUrlRedirectController">
-        <property name="strictParameterMatching" value="false" />
-        <property name="portalUrlProvider" ref="portalUrlProvider" />
-        <property name="portletFunctionalName" value="CourseGuide-Browse-Courses" />
-        <property name="windowState" value="detached" />
+    <bean id="browseBySubjectRedirect" parent="abstractRedirectBean">
         <property name="staticParameters">
             <map>
                 <entry key="action" value="subjectSearch" />
@@ -35,11 +44,7 @@
         </property>
     </bean>
     
-    <bean id="courseDetailsRedirect" class="edu.wisc.my.redirect.PortalUrlRedirectController">
-        <property name="strictParameterMatching" value="false" />
-        <property name="portalUrlProvider" ref="portalUrlProvider" />
-        <property name="portletFunctionalName" value="CourseGuide-Browse-Courses" />
-        <property name="windowState" value="detached" />
+    <bean id="courseDetailsRedirect" parent="abstractRedirectBean">
         <property name="staticParameters">
             <map>
                 <entry key="action" value="courseDetail" />
@@ -55,7 +60,7 @@
             </map>
         </property>
     </bean>
-    
+
     <bean id="courseGuideTabRedirect" class="edu.wisc.my.redirect.TabSelectingUrlRedirectController">
         <property name="portalUrlProvider" ref="portalUrlProvider" />
         <property name="publicTabIndex" value="1" />

--- a/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/applicationContext.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
     
     <bean id="browseByTitleRedirect" class="edu.wisc.my.redirect.PortalUrlRedirectController">
         <property name="strictParameterMatching" value="false" />

--- a/src/main/webapp/WEB-INF/redirectorServletContext.xml
+++ b/src/main/webapp/WEB-INF/redirectorServletContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd"
->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <bean class="org.springframework.web.servlet.handler.SimpleUrlHandlerMapping">
         <property name="order" value="0"/>


### PR DESCRIPTION
We could do more to make the redirect links more user-friendly (see the arcane parameter values required for [instructionMode](https://wiki.doit.wisc.edu/confluence/display/CRSGD/Course+Guide+Public+URLs)), but for the sake of expedience this will get the job done for now, and we may not need to support this portlet for much longer.